### PR TITLE
Fix blank responses on reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ regolo chat
 **Options:**
 - `--no-hide`: Display API key while typing
 - `--disable-newlines`: Replace newlines with spaces in responses
-- `--api-key <key>`: Provide API key directly instead of being prompted
+- `--api-key <key>`: Provide an API key directly instead of being prompted
+- `--max-tokens`: Specify max tokens for the response
 
 **Example:**
 ```bash

--- a/src/regolo/cli.py
+++ b/src/regolo/cli.py
@@ -723,7 +723,8 @@ def get_available_models(api_key: str, model_type: str):
 @click.option('--api-key', required=False, help='The API key used to chat with Regolo.')
 @click.option('--disable-newlines', required=False, is_flag=True, default=False,
               help='Disable new lines, they will be replaced with space character')
-def chat(no_hide: bool, api_key: str, disable_newlines: bool):
+@click.option('--max-tokens', default=2048, help='Max tokens per response (default: 2048)')
+def chat(no_hide: bool, api_key: str, disable_newlines: bool, max_tokens: int):
     if not api_key:
         api_key = click.prompt("Insert your regolo API key", hide_input=not no_hide)
     available_models: list[dict] = regolo.RegoloClient.get_available_models(api_key, model_info=True)
@@ -767,17 +768,29 @@ def chat(no_hide: bool, api_key: str, disable_newlines: bool):
         if user_input == "/bye":
             exit(0)
         # get chat response and save in the client
-        response = client.run_chat(user_input, stream=True, full_output=False)
+        response = client.run_chat(user_input, stream=True, full_output=False, max_tokens=max_tokens)
 
         # print output
+        was_thinking = False
         while True:
             try:
                 res = next(response)
-                if res[0]:
-                    click.echo(res[0] + ":")
+                if res is None:
+                    continue
+                is_thinking = res[0] == "thinking"
+                text = res[1]
+                if is_thinking and not was_thinking:
+                    click.echo(click.style("Thinking...", dim=True, italic=True))
+                    was_thinking = True
+                elif not is_thinking and was_thinking and text:
+                    click.echo(click.style("\n─────────────────────\n", dim=True))
+                    was_thinking = False
                 if disable_newlines:
-                    res[1] = res[1].replace("\n", " ")
-                click.echo(res[1], nl=False)
+                    text = text.replace("\n", " ")
+                if is_thinking:
+                    click.echo(click.style(text, dim=True), nl=False)
+                else:
+                    click.echo(text, nl=False)
             except StopIteration:
                 break
 

--- a/src/regolo/client/regolo_client.py
+++ b/src/regolo/client/regolo_client.py
@@ -227,7 +227,7 @@ class RegoloClient:
                 try:
                     # Repair and parse the JSON chunk
                     data_chunk = json.loads(json_repair.repair_json(decoded_line))
-                except (Exception,):
+                except Exception:
                     continue
 
                 if full_output:
@@ -419,22 +419,31 @@ class RegoloClient:
         :return for stream=False, full_output=True: Tuple, which consists of role and content of response.
         """
 
+        _state = {"in_reasoning": False}
+
         def handle_search_text_chat_completions(data: dict) -> Optional[tuple[Role, Content]]:
             """
             Internal method, describes how RegoloClient.create_stream_generator() should handle
-            output from chat_completions.
+            output from chat_completions. Reasoning tokens are rendered separately in the CLI (dim + "Thinking..." header).
             """
+            def resolve(delta: dict) -> tuple[Role, Content]:
+                content = delta.get("content")
+                reasoning = delta.get("reasoning_content")
+                if content:
+                    _state["in_reasoning"] = False
+                    return "", content
+                elif reasoning:
+                    _state["in_reasoning"] = True
+                    return "thinking", reasoning
+                return "", ""
+
             if isinstance(data, dict):
                 delta = data.get("choices", [{}])[0].get("delta", {})
-                out_role: Role = delta.get("role", "")
-                out_content: Content = delta.get("content", "")
-                return out_role, out_content
+                return resolve(delta)
             elif isinstance(data, list):
                 for element in data:
                     delta = element.get("choices", [{}])[0].get("delta", {})
-                    out_role: Role = delta.get("role", "")
-                    out_content: Content = delta.get("content", "")
-                    return out_role, out_content
+                    return resolve(delta)
             return None
 
         # Use the default API key if not provided


### PR DESCRIPTION
Problem                                                                                                                                  
                  
  When using regolo chat with reasoning models, the assistant appeared completely frozen — no output was printed,       
  neither during the thinking phase nor for the final response.                                                                            

  Two independent bugs caused this:

  1. max_tokens too low

  run_chat had a hardcoded default of max_tokens=200. Reasoning models spend a large portion of the token budget on internal thinking
  (reasoning_content) before producing the visible answer. With only 200 tokens, the budget was exhausted during reasoning, leaving 0
  tokens for the final response.

  2. reasoning_content silently ignored

  handle_search_text_chat_completions only read delta.get("content") and discarded reasoning_content entirely. During the whole thinking
  phase, nothing was printed — the assistant looked stuck.

  ---
  Solution

  src/regolo/client/regolo_client.py

  - Added an inner resolve() function that distinguishes content from reasoning_content and returns a "thinking" role tag for reasoning
  tokens.
  - Added _state["in_reasoning"] to track the transition between thinking and answer phases.

  src/regolo/cli.py

  - Added --max-tokens flag (default: 2048, user-configurable) forwarded to run_chat.
  - Added differentiated rendering for the thinking phase:
    - Thinking... header (dim + italic) on first reasoning token
    - Reasoning text rendered in dim style
    - Visual separator ───────────────────── on transition to the final answer

  ---
  Test Plan

  - Run regolo chat with a reasoning model ) and verify thinking tokens stream in real-time with dim styling
  - Verify the ───────────────────── separator appears before the final answer, which is printed at full brightness
  - Test --max-tokens 512 and --max-tokens 4096 to confirm the flag is forwarded correctly
  - Verify non-reasoning models (no reasoning_content in deltas) continue to work as before